### PR TITLE
Add support for Minitest >=5

### DIFF
--- a/lib/test_declarative.rb
+++ b/lib/test_declarative.rb
@@ -1,6 +1,7 @@
 targets = [Module]
 targets << Test::Unit::TestCase     if defined?(Test::Unit::TestCase)
 targets << MiniTest::Unit::TestCase if defined?(MiniTest::Unit::TestCase)
+targets << Minitest::Test           if defined?(Minitest::Test)
 
 targets.each do |target|
   target.class_eval do

--- a/test/test_declarative_test.rb
+++ b/test/test_declarative_test.rb
@@ -1,17 +1,44 @@
 $: << File.expand_path('../../lib', __FILE__)
 
-require 'test/unit'
+# Test with test/unit for older Rubies
+begin
+  require 'test/unit'
+  require 'test/unit/testresult'
+  if RUBY_VERSION < '1.9.1'
+    # test/unit
+    TEST_CASE = Test::Unit::TestCase
+    RUNNER = Test::Unit::TestResult
+    MINITEST_5 = false
+  else
+    # Minitest < 5
+    TEST_CASE = Test::Unit::TestCase
+    RUNNER = MiniTest::Unit
+    MINITEST_5 = false
+  end
+rescue LoadError, StandardError
+  # Minitest >= 5
+  require 'minitest/autorun'
+  TEST_CASE = Minitest::Test
+  RUNNER = Minitest::Unit
+  MINITEST_5 = true
+end
+
 require 'test_declarative'
 
-class TestDeclarativeTest < Test::Unit::TestCase
+class TestDeclarativeTest < TEST_CASE
   def test_responds_to_test
     assert self.class.respond_to?(:test)
   end
   
   def test_adds_a_test_method
     called = false
-    assert_nothing_raised { Test::Unit::TestCase.test('some test') { called = true } }
-    Test::Unit::TestCase.new(:'test_some_test').run((RUBY_VERSION < '1.9.1' ? Test::Unit::TestResult : MiniTest::Unit).new) {}
+    TEST_CASE.test('some test') { called = true }
+    case MINITEST_5
+    when false
+      TEST_CASE.new(:'test_some_test').run(RUNNER.new) {}
+    when true
+      TEST_CASE.new(:'test_some_test').run() {}
+    end
     assert called
   end
 end

--- a/test_declarative.gemspec
+++ b/test_declarative.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
   s.required_rubygems_version = '>= 1.3.6'
+  s.add_development_dependency 'minitest', '>= 5.0.0'
 end


### PR DESCRIPTION
- add Minitest 5 support
- change tests to work with both test/unit (if available) and Minitest 5
- fix the test suite on Ruby 1.8.7 by explicitely requiring test/unit/testresult
