### PR TITLE
Improve test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: ruby
+
+sudo: false
+
+before_install:
+  - gem install bundler
+
+rvm:
+  - 2.0.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.1
+  - ruby-head
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem 'rake', '~> 12.0.0'
+gem 'test-unit', '~> 3.2.3'
+gem 'minitest', '~> 5.10.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/**/*_test.rb"]
+  t.warning = true
+  t.verbose = true
+end
+
+task :default => :test


### PR DESCRIPTION
I want to to suggest `test_dclaretive` using Travis CI test environment.
I prepared the environment to use it.
Using CI must help us to develop `test_dclaretive`.

This PR is including #4  => not including #4.
See commits on the PR.

Below are summary of this PR.

   * Add Rakefile, Gemfile, .travis.yml.
    * Add a list of offcially supported Ruby to .travis.yml.
    * Add ruby-head to Travis as allow_failures.
      allow_failures is because it's good to know new version Ruby's issue
      as faster before the release.
    * fast_finish is to get the Travis result as faster
      without waiting the result of the "allow_failures" items.
      See https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/

I tested on my local environment.

```
$ ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]

$ bundle -v
Bundler version 1.14.6

$ git clone git@github.com:svenfuchs/test_declarative.git

$ cd test_declarative

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * bundler (1.14.6)
  * minitest (5.10.1)
  * power_assert (1.0.1)
  * rake (12.0.0)
  * test-unit (3.2.3)
  * test_declarative (0.0.5)

$ bundle exec rake -T
rake test  # Run tests

$ bundle exec rake
...
2 runs, 2 assertions, 0 failures, 0 errors, 0 skips
```

Is it possible to merge the PR?
Is is possible to enable below Travis CI?
https://travis-ci.org/svenfuchs/test_declarative
