### PR TITLE
Add rbx, jruby as allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,12 @@ rvm:
   - 2.3.3
   - 2.4.1
   - ruby-head
+  - rbx
+  - jruby
 
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: rbx
+    - rvm: jruby
   fast_finish: true


### PR DESCRIPTION
Add those platforms referring "i18n" that is one of the popular project
"test_declarative" is used for.
https://github.com/svenfuchs/i18n/blob/master/.travis.yml