### PR TITLE
Add test cases for Travis CI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,31 @@ rvm:
   - 2.3.3
   - 2.4.1
   - ruby-head
-  - rbx
   - jruby
 
+gemfile:
+  - Gemfile
+  - gemfiles/Gemfile.minitest4
+  - gemfiles/Gemfile.unit-test
+  - gemfiles/Gemfile.empty
+
 matrix:
+  exclude:
+    - rvm: 2.2.6
+      gemfile: gemfiles/Gemfile.empty
+    - rvm: 2.3.3
+      gemfile: gemfiles/Gemfile.empty
+    - rvm: 2.4.1
+      gemfile: gemfiles/Gemfile.empty
+    - rvm: ruby-head
+      gemfile: gemfiles/Gemfile.empty
+    - rvm: rbx
+      gemfile: gemfiles/Gemfile.empty
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.empty
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx
     - rvm: jruby
+    # TODO fix this.
+    - gemfile: gemfiles/Gemfile.unit-test
   fast_finish: true

--- a/gemfiles/Gemfile.empty
+++ b/gemfiles/Gemfile.empty
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec :path => '..'
+
+gem 'rake', '~> 12.0.0'
+# This Gemfile is to test stdlib's unit-test and minitest for old Ruby.

--- a/gemfiles/Gemfile.minitest4
+++ b/gemfiles/Gemfile.minitest4
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gemspec
+gemspec :path => '..'
 
 gem 'rake', '~> 12.0.0'
-gem 'minitest', '~> 5.10.1'
+gem 'minitest', '< 5'

--- a/gemfiles/Gemfile.unit-test
+++ b/gemfiles/Gemfile.unit-test
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gemspec
+gemspec :path => '..'
 
 gem 'rake', '~> 12.0.0'
-gem 'minitest', '~> 5.10.1'
+gem 'test-unit', '~> 3.2.3'

--- a/test/test_declarative_test.rb
+++ b/test/test_declarative_test.rb
@@ -1,26 +1,43 @@
-$: << File.expand_path('../../lib', __FILE__)
+$LOAD_PATH << File.expand_path('../../lib', __FILE__)
 
 # Test with test/unit for older Rubies
-begin
-  require 'test/unit'
-  require 'test/unit/testresult'
-  if RUBY_VERSION < '1.9.1'
-    # test/unit
-    TEST_CASE = Test::Unit::TestCase
-    RUNNER = Test::Unit::TestResult
-    MINITEST_5 = false
-  else
-    # Minitest < 5
-    TEST_CASE = Test::Unit::TestCase
-    RUNNER = MiniTest::Unit
-    MINITEST_5 = false
-  end
-rescue LoadError, StandardError
+def gemfile_name
+  gemfile = ENV['BUNDLE_GEMFILE']
+  raise 'bundler is required for test.' unless gemfile
+  File.basename(gemfile)
+end
+
+gemfile = gemfile_name
+case gemfile
+when 'Gemfile'
   # Minitest >= 5
   require 'minitest/autorun'
   TEST_CASE = Minitest::Test
   RUNNER = Minitest::Unit
   MINITEST_5 = true
+when 'Gemfile.minitest4'
+  # Minitest < 5
+  require 'minitest/autorun'
+  TEST_CASE = MiniTest::Unit::TestCase
+  RUNNER = MiniTest::Unit
+  MINITEST_5 = false
+when 'Gemfile.unit-test'
+  # Latest test-unit
+  require 'test-unit'
+  require 'test/unit/testresult'
+  TEST_CASE = Test::Unit::TestCase
+  RUNNER = Test::Unit::TestResult
+  MINITEST_5 = false
+when 'Gemfile.empty'
+  # Test for stdlib minitest.
+  # test-unit and minitest were removed from stdlib at Ruby 2.2.
+  # https://bugs.ruby-lang.org/issues/9711
+  require 'minitest/autorun'
+  TEST_CASE = MiniTest::Unit::TestCase
+  RUNNER = MiniTest::Unit
+  MINITEST_5 = false
+else
+  raise "Unknown gemfile: #{gemfile}"
 end
 
 require 'test_declarative'
@@ -29,15 +46,15 @@ class TestDeclarativeTest < TEST_CASE
   def test_responds_to_test
     assert self.class.respond_to?(:test)
   end
-  
+
   def test_adds_a_test_method
     called = false
     TEST_CASE.test('some test') { called = true }
     case MINITEST_5
     when false
-      TEST_CASE.new(:'test_some_test').run(RUNNER.new) {}
+      TEST_CASE.new(:test_some_test).run(RUNNER.new) {}
     when true
-      TEST_CASE.new(:'test_some_test').run() {}
+      TEST_CASE.new(:test_some_test).run {}
     end
     assert called
   end


### PR DESCRIPTION
- Add test cases for Travis CI.
  - A case that only latest minitest5 is installed 
  - A case that only minitest4 is installed.
  - A case that only latest unit-test is installed
  - A case that stdlib's minitest is used for old Ruby version < 2.2.
- Fix for Rubocop 0.48.0.
- Add .gitignore.