### PR TITLE
Removed invalid rbx test case on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
       gemfile: gemfiles/Gemfile.empty
     - rvm: ruby-head
       gemfile: gemfiles/Gemfile.empty
-    - rvm: rbx
-      gemfile: gemfiles/Gemfile.empty
     - rvm: jruby
       gemfile: gemfiles/Gemfile.empty
   allow_failures:


### PR DESCRIPTION
Remove `rbx` test typo for Travis CI.
