### PR TITLE
Output deprecated warning for test framework that has test declarative style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,4 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby
-    # TODO fix this.
-    - gemfile: gemfiles/Gemfile.unit-test
   fast_finish: true

--- a/lib/test_declarative.rb
+++ b/lib/test_declarative.rb
@@ -4,6 +4,11 @@ targets << MiniTest::Unit::TestCase if defined?(MiniTest::Unit::TestCase)
 targets << Minitest::Test           if defined?(Minitest::Test)
 
 targets.each do |target|
+  if target.respond_to? :test
+    warn "test_declarative is deprecated for #{target}"
+    next
+  end
+
   target.class_eval do
     def test(name, &block)
       test_name = "test_#{name.gsub(/\s+/,'_')}".to_sym

--- a/test/test_declarative_test.rb
+++ b/test/test_declarative_test.rb
@@ -7,27 +7,24 @@ def gemfile_name
   File.basename(gemfile)
 end
 
-gemfile = gemfile_name
-case gemfile
+GEMFILE = gemfile_name
+case GEMFILE
 when 'Gemfile'
   # Minitest >= 5
   require 'minitest/autorun'
   TEST_CASE = Minitest::Test
   RUNNER = Minitest::Unit
-  MINITEST_5 = true
 when 'Gemfile.minitest4'
   # Minitest < 5
   require 'minitest/autorun'
   TEST_CASE = MiniTest::Unit::TestCase
   RUNNER = MiniTest::Unit
-  MINITEST_5 = false
 when 'Gemfile.unit-test'
   # Latest test-unit
   require 'test-unit'
   require 'test/unit/testresult'
   TEST_CASE = Test::Unit::TestCase
   RUNNER = Test::Unit::TestResult
-  MINITEST_5 = false
 when 'Gemfile.empty'
   # Test for stdlib minitest.
   # test-unit and minitest were removed from stdlib at Ruby 2.2.
@@ -35,7 +32,6 @@ when 'Gemfile.empty'
   require 'minitest/autorun'
   TEST_CASE = MiniTest::Unit::TestCase
   RUNNER = MiniTest::Unit
-  MINITEST_5 = false
 else
   raise "Unknown gemfile: #{gemfile}"
 end
@@ -50,11 +46,16 @@ class TestDeclarativeTest < TEST_CASE
   def test_adds_a_test_method
     called = false
     TEST_CASE.test('some test') { called = true }
-    case MINITEST_5
-    when false
-      TEST_CASE.new(:test_some_test).run(RUNNER.new) {}
-    when true
+    case GEMFILE
+    when 'Gemfile'
       TEST_CASE.new(:test_some_test).run {}
+    when 'Gemfile.unit-test'
+      # This module does not inherit unit test.
+      # It has already implemented from test unit v2.3.0.
+      # Run original test unit just in case.
+      TEST_CASE.new("test: some test").run(RUNNER.new) {}
+    else
+      TEST_CASE.new(:test_some_test).run(RUNNER.new) {}
     end
     assert called
   end


### PR DESCRIPTION
Fixes https://github.com/svenfuchs/test_declarative/issues/14
test-unit has the declarative style from v 2.3.0.
