### PR TITLE
Suppress the deprecation warning for Minitest::Test

### DIFF
--- a/lib/test_declarative.rb
+++ b/lib/test_declarative.rb
@@ -1,7 +1,8 @@
-targets = [Module]
+targets = []
 targets << Test::Unit::TestCase     if defined?(Test::Unit::TestCase)
 targets << MiniTest::Unit::TestCase if defined?(MiniTest::Unit::TestCase)
 targets << Minitest::Test           if defined?(Minitest::Test)
+targets << Module
 
 targets.each do |target|
   if target.respond_to? :test


### PR DESCRIPTION
Fix #20

`test` method was defined in `Module` first, so this PR changed it to be defined in `Module` last.

- Before:
  ```
  $ ruby mytest_mini.rb
  test_declarative is deprecated for Minitest::Unit::TestCase
  test_declarative is deprecated for Minitest::Test
  Run options: --seed 48646
  
  # Running:
  
  .
  
  Finished in 0.005164s, 193.6620 runs/s, 193.6620 assertions/s.
  1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
  ```
- After:
  ```
  $ ruby mytest_mini.rb
  Run options: --seed 38368
  
  # Running:
  
  .
  
  Finished in 0.007170s, 139.4641 runs/s, 139.4641 assertions/s.
  1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
  ```
(Please see #20 for the contents of `mytest_mini.rb`.)