### PR TITLE
Use https for GitHub link

### DIFF
--- a/test_declarative.gemspec
+++ b/test_declarative.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version      = TestDeclarative::VERSION
   s.authors      = ['Sven Fuchs']
   s.email        = 'svenfuchs@artweb-design.de'
-  s.homepage     = 'http://github.com/svenfuchs/test_declarative'
+  s.homepage     = 'https://github.com/svenfuchs/test_declarative'
   s.license      = 'MIT'
   s.summary      = 'Simply adds a declarative test method syntax to test/unit'
   s.description  = 'Simply adds a declarative test method syntax to test/unit.'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/test_declarative or some tools or APIs that use the gem's metadata.