### PR TITLE
Use Minitest::Test as a test runner

### DIFF
--- a/test/test_declarative_test.rb
+++ b/test/test_declarative_test.rb
@@ -13,7 +13,7 @@ when 'Gemfile'
   # Minitest >= 5
   require 'minitest/autorun'
   TEST_CASE = Minitest::Test
-  RUNNER = Minitest::Unit
+  RUNNER = Minitest::Test
 when 'Gemfile.minitest4'
   # Minitest < 5
   require 'minitest/autorun'


### PR DESCRIPTION
The Minitest::Unit is deprecated since Minitest 5.0 and it was recenlty put behind environment variable:

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6